### PR TITLE
Allow overriding the argoexec binary location

### DIFF
--- a/argo-argoexec/Dockerfile.ODH
+++ b/argo-argoexec/Dockerfile.ODH
@@ -1,6 +1,6 @@
 ARG SOURCE_CODE=.
 
-FROM registry.redhat.io/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE
@@ -16,11 +16,11 @@ COPY ${SOURCE_CODE}/ ./
 # Set the /workspace directory as safe for Git
 RUN git config --global --add safe.directory /workspace
 
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make dist/argoexec GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE}
-
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE} CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -v  -o dist/argoexec-fips ./cmd/argoexec
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE} CGO_ENABLED=0 go build -ldflags '-extldflags -static' -v  -o dist/argoexec ./cmd/argoexec
 
 ####################################################################################################
-FROM registry.redhat.io/ubi8/ubi-minimal:8.10 AS argoexec
+FROM registry.redhat.io/ubi9/ubi-minimal:9.5 AS argoexec
 
 
 ARG CI_CONTAINER_VERSION
@@ -28,11 +28,12 @@ ARG CI_CONTAINER_VERSION
 WORKDIR /bin
 
 COPY --from=builder /workspace/dist/argoexec /bin/
+COPY --from=builder /workspace/dist/argoexec-fips /bin/
 COPY --from=builder /etc/mime.types /etc/mime.types
 COPY --from=builder /workspace/hack/ssh_known_hosts /etc/ssh/
 COPY --from=builder /workspace/hack/nsswitch.conf /etc/
 
-RUN chmod +x /bin/argoexec
+RUN chmod +x /bin/argoexec && chmod +x /bin/argoexec-fips
 
 USER 2000
 

--- a/argo-workflowcontroller/Dockerfile.ODH
+++ b/argo-workflowcontroller/Dockerfile.ODH
@@ -1,6 +1,6 @@
 ARG SOURCE_CODE=.
 
-FROM registry.redhat.io/ubi8/go-toolset:1.21 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
 
 # Build args to be used at this step
 ARG SOURCE_CODE
@@ -16,10 +16,10 @@ COPY ${SOURCE_CODE}/ ./
 # Set the /workspace directory as safe for Git
 RUN git config --global --add safe.directory /workspace
 
-RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build make dist/workflow-controller GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE}
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build GIT_COMMIT=${GIT_COMMIT} GIT_TAG=${GIT_TAG} GIT_TREE_STATE=${GIT_TREE_STATE} CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build  -tags strictfipsruntime -v  -o dist/workflow-controller ./cmd/workflow-controller
 
 ####################################################################################################
-FROM registry.redhat.io/ubi8/ubi-minimal:8.10 AS workflow-controller
+FROM registry.redhat.io/ubi9/ubi-minimal:9.5 AS workflow-controller
 
 
 ARG CI_CONTAINER_VERSION

--- a/workflow/common/common.go
+++ b/workflow/common/common.go
@@ -157,6 +157,8 @@ const (
 	EnvAgentTaskWorkers = "ARGO_AGENT_TASK_WORKERS"
 	// EnvAgentPatchRate is the rate that the Argo Agent will patch the Workflow TaskSet
 	EnvAgentPatchRate = "ARGO_AGENT_PATCH_RATE"
+	// EnvVarArgoExecPath is for overriding the default path of the argoexec binary
+	EnvVarArgoExecPath = "ARGO_EXEC_PATH"
 
 	// Finalizer to block deletion of the workflow if deletion of artifacts fail for some reason.
 	FinalizerArtifactGC = workflow.WorkflowFullName + "/artifact-gc"

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -520,8 +521,16 @@ func substitutePodParams(pod *apiv1.Pod, globalParams common.Parameters, tmpl *w
 }
 
 func (woc *wfOperationCtx) newInitContainer(tmpl *wfv1.Template) apiv1.Container {
+	argoExecPath := os.Getenv("ARGO_EXEC_PATH")
+	if argoExecPath != "" {
+		log.Infof("Using argoexec path from environment variable: %s", argoExecPath)
+	} else {
+		argoExecPath = "argoexec"
+	}
+
 	ctr := woc.newExecContainer(common.InitContainerName, tmpl)
-	ctr.Command = []string{"argoexec", "init", "--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.executorLogFormat()}
+	ctr.Command = []string{argoExecPath, "init", "--loglevel", getExecutorLogLevel(), "--log-format", woc.controller.executorLogFormat()}
+
 	return *ctr
 }
 

--- a/workflow/executor/emissary/binary.go
+++ b/workflow/executor/emissary/binary.go
@@ -1,19 +1,20 @@
 package emissary
 
 import (
+	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/argoproj/argo-workflows/v3/workflow/common"
 )
 
 func copyBinary() error {
-	name, err := exec.LookPath("argoexec")
+	name, err := os.Executable()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get the argoexec path: %w", err)
 	}
+
 	in, err := os.Open(filepath.Clean(name))
 	if err != nil {
 		return err


### PR DESCRIPTION
This introduces the ARGO_EXEC_PATH environment variable and when set, the value is used as the path to copy to /var/run/argo/argoexec.

The specific usecase is to allow building one container image with a CGO_ENABLED=1 binary of argoexec and one with CGO_ENABLED=0. When the cluster must be FIPS compliant, we use the CGO_ENABLED=1 binary to use FIPS approved C libraries by setting the ARGO_EXEC_PATH environment variable. When the cluster does not require FIPS, we will just use the CGO_ENABLED=0 binary which allows much more flexibility for the container image used by the main container as the C libraries don't need to match from the build environment.

This also updates to UBI 9 to match RHOAI 2.21.

Relates:
https://issues.redhat.com/browse/RHOAIENG-24702
